### PR TITLE
Add mandatory pre-commit validation guidelines

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -116,15 +116,38 @@ async def endpoint(
 
 ## Git & CI
 
+### Mandatory Pre-Commit Validation
+
+**CRITICAL: You MUST run these checks before EVERY commit and before opening ANY PR. No exceptions. Never commit or open a PR with failing checks.**
+
+```bash
+just check        # Lint (Ruff) + format check (Ruff) + type check (Pyright)
+just test         # Run all unit tests
+```
+
+If either command fails, fix ALL errors before committing. Type errors must be fixed manually (update type annotations, add missing types, fix incompatible types). Lint and format issues can often be auto-fixed with `just format` and `just lint-fix`.
+
+**Without Docker / without `just`:**
+
+```bash
+cd backend
+uv run ruff check app/              # Lint
+uv run ruff format --check app/     # Format check
+uv run pyright app/                 # Type check
+uv run pytest tests/unit/ -v        # Unit tests
+```
+
 ### Commits
 - **Descriptive commit messages** - What and why
 - **Small, focused commits** - One logical change per commit
 - **Never commit secrets** - Check before committing
+- **Always validate before committing** - `just check && just test` must pass
 
 ### CI/CD
 - **No hardcoded secrets** in CI configuration
 - **Use environment variables** for sensitive data
 - **Fast unit tests in CI** - Save integration tests for optional runs
+- **CI gates PR merge** - Lint, type check, and tests must pass before merging
 
 ## Project-Specific
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Claude Code Instructions
+
+## Mandatory Pre-Commit Validation
+
+**CRITICAL: You MUST run these checks before every commit and before opening any PR. No exceptions.**
+
+```bash
+just check        # Lint (Ruff) + format check (Ruff) + type check (Pyright)
+just test         # Run all unit tests
+```
+
+If either command fails, fix ALL errors before committing. Do NOT commit or open a PR with failing type checks, lint errors, or test failures.
+
+**If running outside Docker / without `just`:**
+
+```bash
+cd backend
+uv run ruff check app/              # Lint
+uv run ruff format --check app/     # Format check
+uv run pyright app/                 # Type check
+uv run pytest tests/unit/ -v        # Unit tests
+```
+
+## Pre-PR Checklist
+
+Before opening any pull request, verify:
+
+1. `just check` passes (zero lint errors, zero format errors, zero type errors)
+2. `just test` passes (all unit tests green)
+3. No secrets or `.env.secrets` files are staged
+4. Commit messages are descriptive
+
+## Quick Reference
+
+- **Format code:** `just format` (auto-fixes formatting and import sorting)
+- **Fix lint issues:** `just lint-fix` (auto-fixes what it can)
+- **Type errors:** Must be fixed manually — update type annotations, add missing types, fix incompatible types
+- **Run specific tests:** `just test-file tests/unit/test_ai_routes.py`
+
+## Project Conventions
+
+See `.cursorrules` for full coding standards. Key points:
+
+- All imports at top of file (never inline)
+- Type hints on all function parameters and return values
+- Modern Python syntax: `str | None` not `Optional[str]`, `list[str]` not `List[str]`
+- Models in `app/models/`, routes in `app/routes/`, logic in `app/services/`
+- Keep routes thin — business logic goes in services
+- Log errors, return generic messages to users

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,27 @@
 # Mnemos - Agent Context
 
-Quick-reference for AI agents (Cursor, Copilot, etc.) working in this repository.
+Quick-reference for AI agents (Cursor, Copilot, Claude Code, etc.) working in this repository.
+
+## Mandatory Pre-Commit Validation
+
+**CRITICAL: You MUST run these checks before EVERY commit and before opening ANY PR. No exceptions. Never commit or open a PR with failing checks.**
+
+```bash
+just check        # Lint (Ruff) + format check (Ruff) + type check (Pyright)
+just test         # Run all unit tests
+```
+
+If either command fails, fix ALL errors before committing. Do NOT skip this step. Do NOT commit with type errors, lint errors, or test failures. CI will reject the PR if these checks fail.
+
+**Without Docker / without `just`:**
+
+```bash
+cd backend
+uv run ruff check app/              # Lint
+uv run ruff format --check app/     # Format check
+uv run pyright app/                 # Type check
+uv run pytest tests/unit/ -v        # Unit tests
+```
 
 ## What Is Mnemos?
 
@@ -201,16 +222,14 @@ just todos        # Find all TODOs
 
 ### Validating Your Changes
 
-Before committing, run these checks to ensure nothing is broken.
-
-**Minimum validation (must pass before every commit):**
+**MANDATORY: Run these checks before EVERY commit and EVERY PR. No exceptions. Do NOT commit or open a PR with any failures.**
 
 ```bash
 just check        # Lint (Ruff) + format check (Ruff) + type check (Pyright)
 just test         # Run all unit tests
 ```
 
-These two commands mirror exactly what CI runs on every push/PR. If they pass locally, CI will pass.
+These two commands mirror exactly what CI runs on every push/PR. If they pass locally, CI will pass. If they fail, fix ALL errors before proceeding.
 
 **Step-by-step validation:**
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive pre-commit validation guidelines across multiple documentation files to ensure code quality standards are consistently enforced before commits and PRs are opened.

## Key Changes
- **CLAUDE.md** (new file): Created dedicated Claude Code instructions with mandatory pre-commit validation requirements, pre-PR checklist, quick reference commands, and project conventions
- **agents.md**: Enhanced with prominent mandatory pre-commit validation section at the top, emphasizing critical nature of running `just check` and `just test` before every commit and PR
- **.cursorrules**: Added detailed "Mandatory Pre-Commit Validation" section under Git & CI guidelines with explicit commands and fallback instructions for non-Docker environments

## Notable Details
- All three files now consistently emphasize that validation checks are **CRITICAL** and **MANDATORY** with "no exceptions" language
- Includes both Docker/`just` command variants and fallback `uv`/`ruff`/`pyright`/`pytest` commands for environments without Docker
- Clarifies that type errors must be fixed manually while lint/format issues can be auto-fixed
- Reinforces that CI will reject PRs with failing checks, making local validation essential
- Maintains consistent messaging across documentation to ensure all AI agents and developers follow the same standards

https://claude.ai/code/session_01GqoUmKbAoXn4ha8tthaZB1