### PR TITLE
Type checking pre-commit hooks

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -116,6 +116,32 @@ async def endpoint(
 
 ## Git & CI
 
+### Pre-Commit / Pre-PR Quality Gate (MANDATORY)
+
+**Before EVERY commit and before opening ANY pull request, you MUST run:**
+
+```bash
+cd backend && uv run --extra dev ruff check app/ && uv run --extra dev ruff format --check app/ && uv run --extra dev pyright app/
+```
+
+Or equivalently:
+
+```bash
+just check-local   # Without Docker (for CI agents and local dev)
+just check         # With Docker dev container
+```
+
+**This is non-negotiable.** No PR should ever be opened with type checking, linting, or formatting failures. If any of these checks fail, fix the issues before committing.
+
+Specifically:
+- **Pyright type checking** must pass with zero errors
+- **Ruff linting** must pass with zero errors
+- **Ruff format check** must pass (code must be properly formatted)
+
+If you introduce new code that causes type errors, fix the type errors before committing. Do not use `type: ignore` comments unless absolutely necessary and justified with a comment explaining why.
+
+Pre-commit hooks are configured (`.pre-commit-config.yaml`) and will run these checks automatically on `git commit`, but you should also run them manually before pushing or opening a PR to catch issues early.
+
 ### Commits
 - **Descriptive commit messages** - What and why
 - **Small, focused commits** - One logical change per commit
@@ -125,6 +151,7 @@ async def endpoint(
 - **No hardcoded secrets** in CI configuration
 - **Use environment variables** for sensitive data
 - **Fast unit tests in CI** - Save integration tests for optional runs
+- **CI status checks (lint, type check, tests) are required to pass before PR merge**
 
 ## Project-Specific
 
@@ -154,8 +181,11 @@ async def endpoint(
 ## Commands
 
 ```bash
-just check        # Lint and type check
+just check        # Lint + format check + type check (via Docker)
+just check-local  # Lint + format check + type check (no Docker, for agents)
 just format       # Format code
 just test         # Run unit tests
 just test-all     # Run all tests (including integration)
+just typecheck    # Run only Pyright type checking
+just lint         # Run only Ruff linting
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,10 @@
+# CI Pipeline - Lint, Type Check, and Test
+#
+# These jobs are required status checks for PR merge.
+# Branch protection should be configured to require:
+#   - "Lint and Type Check" (lint-and-typecheck)
+#   - "Run Tests" (test)
+# See BRANCH_PROTECTION.md for setup instructions.
 name: CI
 
 on:

--- a/BRANCH_PROTECTION.md
+++ b/BRANCH_PROTECTION.md
@@ -1,0 +1,35 @@
+# Branch Protection Setup
+
+Type checks, linting, and tests run in CI on every PR (see `.github/workflows/ci.yml`), but **they do not currently block merging**. To enforce this, you need to configure branch protection rules on GitHub.
+
+## Setup Instructions
+
+1. Go to **Settings > Rules > Rulesets** in your GitHub repository
+2. Click **New ruleset > New branch ruleset**
+3. Configure:
+   - **Name**: `Require CI to pass`
+   - **Enforcement status**: `Active`
+   - **Target branches**: Add `Default branch` (main)
+   - **Branch rules**: Check **Require status checks to pass**
+     - Enable **Require branches to be up to date before merging**
+     - Add these required status checks:
+       - `Lint and Type Check`
+       - `Run Tests`
+4. Click **Create**
+
+## What This Enforces
+
+Once configured, PRs targeting `main` cannot be merged unless:
+- **Pyright type checking** passes with zero errors
+- **Ruff linting** passes with zero errors
+- **Ruff format check** passes
+- **All unit tests** pass
+
+## For AI Agents (Cursor, Claude Code)
+
+Agent instructions in `.cursorrules` and `CLAUDE.md` require running all checks before every commit and PR. Pre-commit hooks (`.pre-commit-config.yaml`) also enforce this locally. This provides defense in depth:
+
+1. **Pre-commit hooks** catch issues at commit time
+2. **Agent instructions** ensure agents run checks proactively
+3. **CI status checks** catch anything that slips through
+4. **Branch protection** prevents merging if CI fails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md - Claude Code Agent Instructions
+
+This file provides instructions for Claude Code (claude-code) when working on the Mnemos project.
+
+## Project Overview
+
+Mnemos is a FastAPI-based Python backend ("Second Brain for Receipts / Manuals / PDFs"). The codebase lives in `backend/` and uses `uv` for package management, `Ruff` for linting/formatting, and `Pyright` for type checking.
+
+## Pre-Commit / Pre-PR Quality Gate (MANDATORY)
+
+**Before EVERY commit and before opening ANY pull request, you MUST run:**
+
+```bash
+cd backend && uv run --extra dev ruff check app/ && uv run --extra dev ruff format --check app/ && uv run --extra dev pyright app/
+```
+
+Or equivalently:
+
+```bash
+just check-local  # Without Docker (for CI agents and local dev)
+just check        # With Docker dev container
+```
+
+**This is non-negotiable.** No PR should ever be opened with type checking, linting, or formatting failures. If any of these checks fail, fix ALL issues before committing or opening a PR.
+
+Specifically:
+- **Pyright type checking** must pass with zero errors
+- **Ruff linting** must pass with zero errors
+- **Ruff format check** must pass (code must be properly formatted)
+
+If you introduce new code that causes type errors, fix the type errors before committing. Do not use `type: ignore` comments unless absolutely necessary and justified with a comment explaining why.
+
+Pre-commit hooks are configured (`.pre-commit-config.yaml`) and will run these checks automatically on `git commit`, but you should also run them manually before pushing or opening a PR to catch issues early.
+
+## Quick Reference
+
+### Key Commands
+
+```bash
+just check        # Lint + format check + type check via Docker (run before every commit)
+just check-local  # Same as above but without Docker (for CI agents and local dev)
+just format       # Auto-format code (run if format check fails)
+just test         # Run unit tests
+just test-all     # Run all tests (including integration)
+just typecheck    # Run only Pyright type checking
+just lint         # Run only Ruff linting
+```
+
+### Direct Commands (without Docker)
+
+```bash
+cd backend
+uv run --extra dev ruff check app/              # Lint
+uv run --extra dev ruff format --check app/     # Format check
+uv run --extra dev ruff format app/             # Auto-format
+uv run --extra dev pyright app/                 # Type check
+uv run pytest tests/unit/ -v                    # Unit tests
+```
+
+## Coding Standards
+
+### Python Style
+- **All imports at the top of the file** -- NEVER use inline imports
+- **Explicit imports**: `from app.models.ai import ChatRequest` not `from app.models import ChatRequest`
+- **Modern type hints**: `str | None` not `Optional[str]`, `list[str]` not `List[str]`
+- **Always use type hints** for function parameters and return values
+
+### Code Organization
+- `app/models/` -- Pydantic schemas only
+- `app/routes/` -- HTTP route handlers only (thin layer)
+- `app/services/` -- Business logic and external service clients
+- Keep routes thin, move logic to services
+- Never define models in route files
+
+### Error Handling
+- Log errors, return generic messages -- never expose internal details
+- Use proper HTTP status codes: 503 (service unavailable), 502 (bad gateway), 500 (internal)
+- Never mention file paths in error responses
+
+### Testing
+- One concept per test, descriptive names (`test_chat_returns_error_when_service_unavailable`)
+- Arrange-Act-Assert pattern
+- Mock external dependencies in unit tests
+- Mark integration tests with `@pytest.mark.integration`
+
+### Documentation
+- Docstrings on all public functions, classes, and modules
+- Comments explain WHY, not WHAT
+- No commented-out code
+
+### Git
+- Descriptive commit messages
+- Small, focused commits
+- Never commit secrets
+- **Always run `just check-local` (or `just check` with Docker) before committing and before opening a PR**
+- CI status checks (lint, type check, tests) are required to pass before PR merge

--- a/Justfile
+++ b/Justfile
@@ -176,9 +176,22 @@ migrate-create message:
 db-status:
     docker compose exec postgres psql -U postgres -d mnemos -c "\dt"
 
-# Check code quality (lint + format check + type check)
+# Check code quality (lint + format check + type check) -- via Docker
 check:
     docker compose exec dev sh -c "cd backend && uv run --extra dev ruff check app/ && uv run --extra dev ruff format --check app/ && uv run --extra dev pyright app/"
+
+# Check code quality locally (no Docker required -- for CI agents and local dev)
+check-local:
+    #!/usr/bin/env bash
+    set -e
+    cd backend
+    echo "Running Ruff linter..."
+    uv run --extra dev ruff check app/
+    echo "Running Ruff format check..."
+    uv run --extra dev ruff format --check app/
+    echo "Running Pyright type checker..."
+    uv run --extra dev pyright app/
+    echo "All checks passed!"
 
 # Format code (formatting + import sorting)
 format:


### PR DESCRIPTION
Enforces type checking and linting before commits/PRs and provides guidance for gating PR merges.

This PR adds explicit instructions for agents to run local quality checks, introduces a `just check-local` command for convenience, and provides a `BRANCH_PROTECTION.md` guide for repository owners to configure GitHub branch rules, which is necessary to prevent PRs with failing CI checks from being merged.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-cabd7fe3-8d80-45f0-8cca-c94ddcb7eb21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cabd7fe3-8d80-45f0-8cca-c94ddcb7eb21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

