### PR TITLE
Memos database storage

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -137,3 +137,36 @@ class Tag(Base):
 
     def __repr__(self) -> str:
         return f"<Tag(id={self.id}, name={self.name!r})>"
+
+
+class Memo(Base):
+    """User memo/note for RAG context."""
+
+    __tablename__ = "memos"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    tags: Mapped[list[str]] = mapped_column(
+        ARRAY(String(100)),
+        nullable=False,
+        server_default="{}",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<Memo(id={self.id}, title={self.title!r})>"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from app.middleware.logging import LoggingMiddleware
 from app.middleware.request_id import RequestIDMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
 from app.models.errors import ErrorDetail, ErrorResponse
-from app.routes import ai, health
+from app.routes import ai, health, memos
 
 # Setup logging
 setup_logging(log_level="DEBUG" if settings.DEBUG else "INFO")
@@ -112,6 +112,7 @@ async def general_exception_handler(request: Request, exc: Exception) -> JSONRes
 # Include routers
 app.include_router(health.router)
 app.include_router(ai.router)
+app.include_router(memos.router)
 
 
 @app.get("/", tags=["Root"])

--- a/backend/app/models/memo.py
+++ b/backend/app/models/memo.py
@@ -1,0 +1,40 @@
+"""Memo/note request and response models."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class MemoCreate(BaseModel):
+    """Request model for creating a memo."""
+
+    title: str | None = Field(None, max_length=500, description="Optional short title for the memo")
+    content: str = Field(..., min_length=1, description="The memo/note content")
+    tags: list[str] = Field(default_factory=list, description="Tags for categorization")
+
+
+class MemoUpdate(BaseModel):
+    """Request model for updating a memo. All fields optional."""
+
+    title: str | None = Field(None, max_length=500, description="Updated title")
+    content: str | None = Field(None, min_length=1, description="Updated content")
+    tags: list[str] | None = Field(None, description="Updated tags")
+
+
+class MemoResponse(BaseModel):
+    """Response model for a single memo."""
+
+    id: uuid.UUID = Field(..., description="Memo unique identifier")
+    title: str | None = Field(None, description="Memo title")
+    content: str = Field(..., description="Memo content")
+    tags: list[str] = Field(default_factory=list, description="Memo tags")
+    created_at: datetime = Field(..., description="When the memo was created")
+    updated_at: datetime = Field(..., description="When the memo was last updated")
+
+
+class MemoListResponse(BaseModel):
+    """Response model for listing memos."""
+
+    memos: list[MemoResponse] = Field(..., description="List of memos")
+    total: int = Field(..., ge=0, description="Total number of memos matching the query")

--- a/backend/app/routes/memos.py
+++ b/backend/app/routes/memos.py
@@ -1,0 +1,76 @@
+"""Memo CRUD route handlers."""
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.base import get_session
+from app.models.memo import MemoCreate, MemoListResponse, MemoResponse, MemoUpdate
+from app.services.memo_service import MemoService
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/memos", tags=["Memos"])
+
+
+def _get_memo_service(session: AsyncSession = Depends(get_session)) -> MemoService:
+    """Dependency that provides a MemoService bound to the current DB session."""
+    return MemoService(session)
+
+
+@router.post("", response_model=MemoResponse, status_code=201)
+async def create_memo(
+    body: MemoCreate,
+    service: MemoService = Depends(_get_memo_service),
+) -> MemoResponse:
+    """Create a new memo/note."""
+    return await service.create_memo(body)
+
+
+@router.get("", response_model=MemoListResponse)
+async def list_memos(
+    tag: str | None = Query(None, description="Filter by tag"),
+    search: str | None = Query(None, description="Search in title and content"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    limit: int = Query(50, ge=1, le=200, description="Max items to return"),
+    service: MemoService = Depends(_get_memo_service),
+) -> MemoListResponse:
+    """List memos with optional tag/search filtering."""
+    return await service.list_memos(tag=tag, search=search, offset=offset, limit=limit)
+
+
+@router.get("/{memo_id}", response_model=MemoResponse)
+async def get_memo(
+    memo_id: uuid.UUID,
+    service: MemoService = Depends(_get_memo_service),
+) -> MemoResponse:
+    """Retrieve a single memo by ID."""
+    memo = await service.get_memo(memo_id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return memo
+
+
+@router.patch("/{memo_id}", response_model=MemoResponse)
+async def update_memo(
+    memo_id: uuid.UUID,
+    body: MemoUpdate,
+    service: MemoService = Depends(_get_memo_service),
+) -> MemoResponse:
+    """Update an existing memo (partial update)."""
+    memo = await service.update_memo(memo_id, body)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return memo
+
+
+@router.delete("/{memo_id}", status_code=204)
+async def delete_memo(
+    memo_id: uuid.UUID,
+    service: MemoService = Depends(_get_memo_service),
+) -> None:
+    """Delete a memo."""
+    deleted = await service.delete_memo(memo_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Memo not found")

--- a/backend/app/services/memo_service.py
+++ b/backend/app/services/memo_service.py
@@ -1,0 +1,110 @@
+"""Service layer for memo CRUD operations."""
+
+import logging
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Memo
+from app.models.memo import MemoCreate, MemoListResponse, MemoResponse, MemoUpdate
+
+logger = logging.getLogger(__name__)
+
+
+class MemoService:
+    """Handles memo persistence and retrieval."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create_memo(self, data: MemoCreate) -> MemoResponse:
+        """Create a new memo and return it."""
+        memo = Memo(
+            title=data.title,
+            content=data.content,
+            tags=data.tags,
+        )
+        self._session.add(memo)
+        await self._session.commit()
+        await self._session.refresh(memo)
+        logger.info("Memo created", extra={"memo_id": str(memo.id)})
+        return _to_response(memo)
+
+    async def get_memo(self, memo_id: uuid.UUID) -> MemoResponse | None:
+        """Retrieve a single memo by ID. Returns None if not found."""
+        memo = await self._session.get(Memo, memo_id)
+        if memo is None:
+            return None
+        return _to_response(memo)
+
+    async def list_memos(
+        self,
+        tag: str | None = None,
+        search: str | None = None,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> MemoListResponse:
+        """List memos with optional filtering by tag or text search."""
+        query = select(Memo)
+        count_query = select(func.count()).select_from(Memo)
+
+        if tag is not None:
+            query = query.where(Memo.tags.any(tag))  # type: ignore[attr-defined]
+            count_query = count_query.where(Memo.tags.any(tag))  # type: ignore[attr-defined]
+
+        if search is not None:
+            pattern = f"%{search}%"
+            search_filter = Memo.content.ilike(pattern) | Memo.title.ilike(pattern)
+            query = query.where(search_filter)
+            count_query = count_query.where(search_filter)
+
+        total_result = await self._session.execute(count_query)
+        total = total_result.scalar_one()
+
+        query = query.order_by(Memo.updated_at.desc()).offset(offset).limit(limit)
+        result = await self._session.execute(query)
+        memos = list(result.scalars().all())
+
+        return MemoListResponse(
+            memos=[_to_response(m) for m in memos],
+            total=total,
+        )
+
+    async def update_memo(self, memo_id: uuid.UUID, data: MemoUpdate) -> MemoResponse | None:
+        """Update an existing memo. Returns None if not found."""
+        memo = await self._session.get(Memo, memo_id)
+        if memo is None:
+            return None
+
+        update_fields = data.model_dump(exclude_unset=True)
+        for field, value in update_fields.items():
+            setattr(memo, field, value)
+
+        await self._session.commit()
+        await self._session.refresh(memo)
+        logger.info("Memo updated", extra={"memo_id": str(memo.id)})
+        return _to_response(memo)
+
+    async def delete_memo(self, memo_id: uuid.UUID) -> bool:
+        """Delete a memo. Returns True if deleted, False if not found."""
+        memo = await self._session.get(Memo, memo_id)
+        if memo is None:
+            return False
+
+        await self._session.delete(memo)
+        await self._session.commit()
+        logger.info("Memo deleted", extra={"memo_id": str(memo_id)})
+        return True
+
+
+def _to_response(memo: Memo) -> MemoResponse:
+    """Convert a Memo ORM instance to a MemoResponse."""
+    return MemoResponse(
+        id=memo.id,
+        title=memo.title,
+        content=memo.content,
+        tags=memo.tags,
+        created_at=memo.created_at,
+        updated_at=memo.updated_at,
+    )

--- a/backend/tests/unit/test_memo_db_model.py
+++ b/backend/tests/unit/test_memo_db_model.py
@@ -1,0 +1,55 @@
+"""Unit tests for Memo ORM model."""
+
+import uuid
+
+from app.db.models import Base, Memo
+
+
+def test_memo_model_has_correct_tablename():
+    """Test Memo model table name."""
+    assert Memo.__tablename__ == "memos"
+
+
+def test_memo_columns_exist():
+    """Test that Memo model has expected columns."""
+    column_names = {col.name for col in Memo.__table__.columns}
+    expected = {"id", "title", "content", "tags", "created_at", "updated_at"}
+    assert expected == column_names
+
+
+def test_memo_repr():
+    """Test Memo string representation."""
+    memo = Memo(id=uuid.uuid4(), title="My Note", content="Some text")
+    assert "My Note" in repr(memo)
+    assert "Memo" in repr(memo)
+
+
+def test_memo_repr_without_title():
+    """Test Memo repr when title is None."""
+    memo = Memo(id=uuid.uuid4(), title=None, content="Some text")
+    assert "Memo" in repr(memo)
+    assert "None" in repr(memo)
+
+
+def test_base_metadata_contains_memos_table():
+    """Test that Base metadata knows about the memos table."""
+    table_names = set(Base.metadata.tables.keys())
+    assert "memos" in table_names
+
+
+def test_memo_content_is_not_nullable():
+    """Test that content column is not nullable."""
+    content_col = Memo.__table__.columns["content"]
+    assert content_col.nullable is False
+
+
+def test_memo_title_is_nullable():
+    """Test that title column is nullable."""
+    title_col = Memo.__table__.columns["title"]
+    assert title_col.nullable is True
+
+
+def test_memo_tags_is_not_nullable():
+    """Test that tags column is not nullable."""
+    tags_col = Memo.__table__.columns["tags"]
+    assert tags_col.nullable is False

--- a/backend/tests/unit/test_memo_models.py
+++ b/backend/tests/unit/test_memo_models.py
@@ -1,0 +1,128 @@
+"""Unit tests for memo Pydantic models."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.memo import MemoCreate, MemoListResponse, MemoResponse, MemoUpdate
+
+
+class TestMemoCreate:
+    """Tests for MemoCreate request model."""
+
+    def test_create_with_content_only(self):
+        """Minimal valid memo requires only content."""
+        memo = MemoCreate(content="Buy groceries")
+        assert memo.content == "Buy groceries"
+        assert memo.title is None
+        assert memo.tags == []
+
+    def test_create_with_all_fields(self):
+        """All fields can be provided."""
+        memo = MemoCreate(
+            title="Shopping",
+            content="Buy groceries",
+            tags=["shopping", "personal"],
+        )
+        assert memo.title == "Shopping"
+        assert memo.content == "Buy groceries"
+        assert memo.tags == ["shopping", "personal"]
+
+    def test_create_rejects_empty_content(self):
+        """Content must not be empty."""
+        with pytest.raises(ValidationError):
+            MemoCreate(content="")
+
+    def test_create_rejects_missing_content(self):
+        """Content is required."""
+        with pytest.raises(ValidationError):
+            MemoCreate()  # type: ignore[call-arg]
+
+
+class TestMemoUpdate:
+    """Tests for MemoUpdate request model."""
+
+    def test_update_all_fields_optional(self):
+        """All fields are optional for partial updates."""
+        update = MemoUpdate()
+        assert update.title is None
+        assert update.content is None
+        assert update.tags is None
+
+    def test_update_with_content(self):
+        """Content can be updated alone."""
+        update = MemoUpdate(content="Updated note")
+        assert update.content == "Updated note"
+
+    def test_update_rejects_empty_content(self):
+        """Content, if provided, must not be empty."""
+        with pytest.raises(ValidationError):
+            MemoUpdate(content="")
+
+    def test_update_exclude_unset(self):
+        """model_dump(exclude_unset=True) only returns provided fields."""
+        update = MemoUpdate(content="New text")
+        dumped = update.model_dump(exclude_unset=True)
+        assert dumped == {"content": "New text"}
+
+
+class TestMemoResponse:
+    """Tests for MemoResponse model."""
+
+    def test_response_serialization(self):
+        """MemoResponse serializes all fields correctly."""
+        now = datetime.now(tz=timezone.utc)
+        memo_id = uuid.uuid4()
+        resp = MemoResponse(
+            id=memo_id,
+            title="Test",
+            content="Hello world",
+            tags=["test"],
+            created_at=now,
+            updated_at=now,
+        )
+        data = resp.model_dump()
+        assert data["id"] == memo_id
+        assert data["title"] == "Test"
+        assert data["content"] == "Hello world"
+        assert data["tags"] == ["test"]
+
+    def test_response_title_optional(self):
+        """Title may be None."""
+        now = datetime.now(tz=timezone.utc)
+        resp = MemoResponse(
+            id=uuid.uuid4(),
+            title=None,
+            content="No title",
+            tags=[],
+            created_at=now,
+            updated_at=now,
+        )
+        assert resp.title is None
+
+
+class TestMemoListResponse:
+    """Tests for MemoListResponse model."""
+
+    def test_list_response(self):
+        """MemoListResponse wraps a list and total count."""
+        now = datetime.now(tz=timezone.utc)
+        memo = MemoResponse(
+            id=uuid.uuid4(),
+            title="A",
+            content="B",
+            tags=[],
+            created_at=now,
+            updated_at=now,
+        )
+        resp = MemoListResponse(memos=[memo], total=1)
+        assert len(resp.memos) == 1
+        assert resp.total == 1
+
+    def test_list_response_empty(self):
+        """Empty list is valid."""
+        resp = MemoListResponse(memos=[], total=0)
+        assert resp.memos == []
+        assert resp.total == 0

--- a/backend/tests/unit/test_memo_routes.py
+++ b/backend/tests/unit/test_memo_routes.py
@@ -1,0 +1,177 @@
+"""Unit tests for memo route handlers."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.main import app
+from app.models.memo import MemoListResponse, MemoResponse
+from app.routes.memos import _get_memo_service
+
+
+@pytest.fixture
+def memo_response():
+    """A sample MemoResponse for test assertions."""
+    return MemoResponse(
+        id=uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        title="Test Memo",
+        content="Hello world",
+        tags=["test"],
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def mock_service(memo_response):
+    """Provide a mock MemoService and wire it into the app."""
+    service = AsyncMock()
+    service.create_memo = AsyncMock(return_value=memo_response)
+    service.get_memo = AsyncMock(return_value=memo_response)
+    service.list_memos = AsyncMock(
+        return_value=MemoListResponse(memos=[memo_response], total=1)
+    )
+    service.update_memo = AsyncMock(return_value=memo_response)
+    service.delete_memo = AsyncMock(return_value=True)
+
+    app.dependency_overrides[_get_memo_service] = lambda: service
+    yield service
+    app.dependency_overrides.pop(_get_memo_service, None)
+
+
+class TestCreateMemo:
+    """Tests for POST /api/v1/memos."""
+
+    def test_create_memo_success(self, client, mock_service):
+        """Successful memo creation returns 201."""
+        response = client.post(
+            "/api/v1/memos",
+            json={"content": "Hello world", "title": "Test Memo", "tags": ["test"]},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["content"] == "Hello world"
+        assert data["title"] == "Test Memo"
+        mock_service.create_memo.assert_awaited_once()
+
+    def test_create_memo_minimal(self, client, mock_service):
+        """Memo can be created with content only."""
+        response = client.post(
+            "/api/v1/memos",
+            json={"content": "Just a note"},
+        )
+        assert response.status_code == 201
+        mock_service.create_memo.assert_awaited_once()
+
+    def test_create_memo_validation_error(self, client, mock_service):
+        """Empty content returns 422."""
+        response = client.post("/api/v1/memos", json={"content": ""})
+        assert response.status_code == 422
+
+    def test_create_memo_missing_content(self, client, mock_service):
+        """Missing content field returns 422."""
+        response = client.post("/api/v1/memos", json={})
+        assert response.status_code == 422
+
+
+class TestGetMemo:
+    """Tests for GET /api/v1/memos/{memo_id}."""
+
+    def test_get_memo_success(self, client, mock_service):
+        """Existing memo returns 200."""
+        memo_id = "12345678-1234-5678-1234-567812345678"
+        response = client.get(f"/api/v1/memos/{memo_id}")
+        assert response.status_code == 200
+        assert response.json()["id"] == memo_id
+
+    def test_get_memo_not_found(self, client, mock_service):
+        """Missing memo returns 404."""
+        mock_service.get_memo = AsyncMock(return_value=None)
+        memo_id = uuid.uuid4()
+        response = client.get(f"/api/v1/memos/{memo_id}")
+        assert response.status_code == 404
+
+    def test_get_memo_invalid_uuid(self, client, mock_service):
+        """Invalid UUID returns 422."""
+        response = client.get("/api/v1/memos/not-a-uuid")
+        assert response.status_code == 422
+
+
+class TestListMemos:
+    """Tests for GET /api/v1/memos."""
+
+    def test_list_memos_success(self, client, mock_service):
+        """List endpoint returns memos and total."""
+        response = client.get("/api/v1/memos")
+        assert response.status_code == 200
+        data = response.json()
+        assert "memos" in data
+        assert "total" in data
+        assert data["total"] == 1
+
+    def test_list_memos_with_tag_filter(self, client, mock_service):
+        """Tag query parameter is forwarded to service."""
+        response = client.get("/api/v1/memos?tag=shopping")
+        assert response.status_code == 200
+        mock_service.list_memos.assert_awaited_once_with(
+            tag="shopping", search=None, offset=0, limit=50
+        )
+
+    def test_list_memos_with_search(self, client, mock_service):
+        """Search query parameter is forwarded to service."""
+        response = client.get("/api/v1/memos?search=groceries")
+        assert response.status_code == 200
+        mock_service.list_memos.assert_awaited_once_with(
+            tag=None, search="groceries", offset=0, limit=50
+        )
+
+    def test_list_memos_pagination(self, client, mock_service):
+        """Offset and limit query parameters are forwarded."""
+        response = client.get("/api/v1/memos?offset=10&limit=5")
+        assert response.status_code == 200
+        mock_service.list_memos.assert_awaited_once_with(
+            tag=None, search=None, offset=10, limit=5
+        )
+
+
+class TestUpdateMemo:
+    """Tests for PATCH /api/v1/memos/{memo_id}."""
+
+    def test_update_memo_success(self, client, mock_service):
+        """Successful update returns 200."""
+        memo_id = "12345678-1234-5678-1234-567812345678"
+        response = client.patch(
+            f"/api/v1/memos/{memo_id}",
+            json={"content": "Updated content"},
+        )
+        assert response.status_code == 200
+        mock_service.update_memo.assert_awaited_once()
+
+    def test_update_memo_not_found(self, client, mock_service):
+        """Update on missing memo returns 404."""
+        mock_service.update_memo = AsyncMock(return_value=None)
+        memo_id = uuid.uuid4()
+        response = client.patch(
+            f"/api/v1/memos/{memo_id}",
+            json={"content": "Updated"},
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteMemo:
+    """Tests for DELETE /api/v1/memos/{memo_id}."""
+
+    def test_delete_memo_success(self, client, mock_service):
+        """Successful delete returns 204."""
+        memo_id = uuid.uuid4()
+        response = client.delete(f"/api/v1/memos/{memo_id}")
+        assert response.status_code == 204
+
+    def test_delete_memo_not_found(self, client, mock_service):
+        """Delete on missing memo returns 404."""
+        mock_service.delete_memo = AsyncMock(return_value=False)
+        memo_id = uuid.uuid4()
+        response = client.delete(f"/api/v1/memos/{memo_id}")
+        assert response.status_code == 404

--- a/backend/tests/unit/test_memo_service.py
+++ b/backend/tests/unit/test_memo_service.py
@@ -1,0 +1,144 @@
+"""Unit tests for MemoService (mocked database session)."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.db.models import Memo
+from app.models.memo import MemoCreate, MemoUpdate
+from app.services.memo_service import MemoService
+
+
+def _make_memo(
+    memo_id: uuid.UUID | None = None,
+    title: str | None = "Test",
+    content: str = "Hello",
+    tags: list[str] | None = None,
+) -> Memo:
+    """Build a Memo ORM instance for testing."""
+    now = datetime.now(tz=timezone.utc)
+    return Memo(
+        id=memo_id or uuid.uuid4(),
+        title=title,
+        content=content,
+        tags=tags or [],
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.fixture
+def session():
+    """Provide a mock async database session."""
+    mock = AsyncMock()
+    mock.add = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def service(session):
+    """Provide a MemoService backed by the mock session."""
+    return MemoService(session)
+
+
+class TestCreateMemo:
+    """Tests for MemoService.create_memo."""
+
+    @pytest.mark.asyncio
+    async def test_create_adds_and_commits(self, service, session):
+        """create_memo adds memo, commits, and refreshes."""
+        memo_obj = _make_memo()
+
+        async def fake_refresh(obj: Memo) -> None:
+            obj.id = memo_obj.id
+            obj.created_at = memo_obj.created_at
+            obj.updated_at = memo_obj.updated_at
+
+        session.refresh = AsyncMock(side_effect=fake_refresh)
+
+        result = await service.create_memo(MemoCreate(content="Hello", tags=["a"]))
+
+        session.add.assert_called_once()
+        session.commit.assert_awaited_once()
+        session.refresh.assert_awaited_once()
+
+
+class TestGetMemo:
+    """Tests for MemoService.get_memo."""
+
+    @pytest.mark.asyncio
+    async def test_get_returns_memo(self, service, session):
+        """get_memo returns MemoResponse when memo exists."""
+        memo = _make_memo()
+        session.get = AsyncMock(return_value=memo)
+
+        result = await service.get_memo(memo.id)
+
+        assert result is not None
+        assert result.id == memo.id
+        assert result.content == memo.content
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_missing(self, service, session):
+        """get_memo returns None when memo does not exist."""
+        session.get = AsyncMock(return_value=None)
+
+        result = await service.get_memo(uuid.uuid4())
+
+        assert result is None
+
+
+class TestUpdateMemo:
+    """Tests for MemoService.update_memo."""
+
+    @pytest.mark.asyncio
+    async def test_update_applies_changes(self, service, session):
+        """update_memo modifies existing memo fields."""
+        memo = _make_memo(content="Old")
+        session.get = AsyncMock(return_value=memo)
+        session.refresh = AsyncMock()
+
+        result = await service.update_memo(
+            memo.id, MemoUpdate(content="New")
+        )
+
+        assert memo.content == "New"
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_returns_none_when_missing(self, service, session):
+        """update_memo returns None when memo does not exist."""
+        session.get = AsyncMock(return_value=None)
+
+        result = await service.update_memo(uuid.uuid4(), MemoUpdate(content="X"))
+
+        assert result is None
+        session.commit.assert_not_awaited()
+
+
+class TestDeleteMemo:
+    """Tests for MemoService.delete_memo."""
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_true(self, service, session):
+        """delete_memo returns True when memo is deleted."""
+        memo = _make_memo()
+        session.get = AsyncMock(return_value=memo)
+
+        result = await service.delete_memo(memo.id)
+
+        assert result is True
+        session.delete.assert_awaited_once_with(memo)
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_false_when_missing(self, service, session):
+        """delete_memo returns False when memo does not exist."""
+        session.get = AsyncMock(return_value=None)
+
+        result = await service.delete_memo(uuid.uuid4())
+
+        assert result is False
+        session.delete.assert_not_awaited()


### PR DESCRIPTION
Add support for storing user-created memos/notes in the database to be used as context for RAG.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-8fe9000d-50c3-469e-b597-6a0ccc92afb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fe9000d-50c3-469e-b597-6a0ccc92afb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

