### PR TITLE
Add image upload and management endpoints with service layer

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_images_and_image_tags_tables.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_images_and_image_tags_tables.py
@@ -1,0 +1,75 @@
+"""add images and image_tags tables
+
+Revision ID: a1b2c3d4e5f6
+Revises: 6694aaa8eac8
+Create Date: 2026-02-16 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "6694aaa8eac8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create images and image_tags tables."""
+    op.create_table(
+        "images",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("filename", sa.String(500), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("mime_type", sa.String(100), nullable=False),
+        sa.Column("file_size_bytes", sa.Integer(), nullable=False),
+        sa.Column("image_data", sa.LargeBinary(), nullable=False),
+        sa.Column("extracted_text", sa.Text(), nullable=True),
+        sa.Column(
+            "owner_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "image_tags",
+        sa.Column(
+            "image_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("images.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "tag_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tags.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop image_tags and images tables."""
+    op.drop_table("image_tags")
+    op.drop_table("images")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, LargeBinary, String, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -37,6 +37,10 @@ class User(Base):
     )
 
     documents: Mapped[list["Document"]] = relationship(
+        back_populates="owner",
+        cascade="all, delete-orphan",
+    )
+    images: Mapped[list["Image"]] = relationship(
         back_populates="owner",
         cascade="all, delete-orphan",
     )
@@ -134,6 +138,72 @@ class Tag(Base):
         secondary="document_tags",
         back_populates="tags",
     )
+    images: Mapped[list["Image"]] = relationship(
+        secondary="image_tags",
+        back_populates="tags",
+    )
 
     def __repr__(self) -> str:
         return f"<Tag(id={self.id}, name={self.name!r})>"
+
+
+class ImageTag(Base):
+    """Association between images and tags (many-to-many)."""
+
+    __tablename__ = "image_tags"
+
+    image_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("images.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    tag_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("tags.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+
+class Image(Base):
+    """Uploaded image model for RAG context."""
+
+    __tablename__ = "images"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    filename: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mime_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    file_size_bytes: Mapped[int] = mapped_column(nullable=False)
+    image_data: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    extracted_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    owner: Mapped["User"] = relationship(back_populates="images")
+    tags: Mapped[list["Tag"]] = relationship(
+        secondary="image_tags",
+        back_populates="images",
+    )
+
+    def __repr__(self) -> str:
+        return f"<Image(id={self.id}, filename={self.filename!r})>"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from app.middleware.logging import LoggingMiddleware
 from app.middleware.request_id import RequestIDMiddleware
 from app.middleware.security import SecurityHeadersMiddleware
 from app.models.errors import ErrorDetail, ErrorResponse
-from app.routes import ai, health
+from app.routes import ai, health, images
 
 # Setup logging
 setup_logging(log_level="DEBUG" if settings.DEBUG else "INFO")
@@ -112,6 +112,7 @@ async def general_exception_handler(request: Request, exc: Exception) -> JSONRes
 # Include routers
 app.include_router(health.router)
 app.include_router(ai.router)
+app.include_router(images.router)
 
 
 @app.get("/", tags=["Root"])

--- a/backend/app/models/images.py
+++ b/backend/app/models/images.py
@@ -1,0 +1,43 @@
+"""Image storage request/response models."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ImageMetadataResponse(BaseModel):
+    """Response model for image metadata (without binary data)."""
+
+    id: uuid.UUID = Field(..., description="Image unique identifier")
+    filename: str = Field(..., description="Original filename")
+    description: str | None = Field(None, description="Image description")
+    mime_type: str = Field(..., description="MIME type of the image")
+    file_size_bytes: int = Field(..., ge=0, description="File size in bytes")
+    extracted_text: str | None = Field(None, description="OCR-extracted text")
+    owner_id: uuid.UUID = Field(..., description="Owner user ID")
+    created_at: datetime = Field(..., description="Upload timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+
+class ImageListResponse(BaseModel):
+    """Response model for listing images."""
+
+    images: list[ImageMetadataResponse] = Field(..., description="List of image metadata")
+    total: int = Field(..., ge=0, description="Total number of images")
+
+
+class ImageUploadResponse(BaseModel):
+    """Response model after successful image upload."""
+
+    id: uuid.UUID = Field(..., description="Newly created image ID")
+    filename: str = Field(..., description="Stored filename")
+    mime_type: str = Field(..., description="Detected MIME type")
+    file_size_bytes: int = Field(..., ge=0, description="File size in bytes")
+
+
+class ImageDeleteResponse(BaseModel):
+    """Response model after successful image deletion."""
+
+    deleted: bool = Field(..., description="Whether the image was deleted")
+    id: uuid.UUID = Field(..., description="Deleted image ID")

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -1,0 +1,129 @@
+"""Image upload, retrieval, and deletion endpoints."""
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.base import get_session
+from app.models.images import (
+    ImageDeleteResponse,
+    ImageListResponse,
+    ImageMetadataResponse,
+    ImageUploadResponse,
+)
+from app.services.image_service import ImageService, get_image_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/images", tags=["Images"])
+
+
+@router.post("", response_model=ImageUploadResponse, status_code=201)
+async def upload_image(
+    file: UploadFile,
+    owner_id: uuid.UUID,
+    description: str | None = None,
+    session: AsyncSession = Depends(get_session),
+    image_service: ImageService = Depends(get_image_service),
+) -> ImageUploadResponse:
+    """Upload a new image to the database."""
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="File must be an image")
+
+    image_data = await file.read()
+    filename = file.filename or "untitled"
+
+    try:
+        image = await image_service.upload_image(
+            session=session,
+            filename=filename,
+            mime_type=file.content_type,
+            image_data=image_data,
+            owner_id=owner_id,
+            description=description,
+        )
+    except ValueError as e:
+        logger.warning(f"Image upload rejected: {e}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return ImageUploadResponse(
+        id=image.id,
+        filename=image.filename,
+        mime_type=image.mime_type,
+        file_size_bytes=image.file_size_bytes,
+    )
+
+
+@router.get("/{image_id}", response_model=ImageMetadataResponse)
+async def get_image(
+    image_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    image_service: ImageService = Depends(get_image_service),
+) -> ImageMetadataResponse:
+    """Get image metadata by ID."""
+    image = await image_service.get_image(session, image_id)
+    if image is None:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    return ImageMetadataResponse(
+        id=image.id,
+        filename=image.filename,
+        description=image.description,
+        mime_type=image.mime_type,
+        file_size_bytes=image.file_size_bytes,
+        extracted_text=image.extracted_text,
+        owner_id=image.owner_id,
+        created_at=image.created_at,
+        updated_at=image.updated_at,
+    )
+
+
+@router.get("", response_model=ImageListResponse)
+async def list_images(
+    owner_id: uuid.UUID,
+    limit: int = 50,
+    offset: int = 0,
+    session: AsyncSession = Depends(get_session),
+    image_service: ImageService = Depends(get_image_service),
+) -> ImageListResponse:
+    """List images for a given owner."""
+    images, total = await image_service.list_images(
+        session=session,
+        owner_id=owner_id,
+        limit=limit,
+        offset=offset,
+    )
+
+    return ImageListResponse(
+        images=[
+            ImageMetadataResponse(
+                id=img.id,
+                filename=img.filename,
+                description=img.description,
+                mime_type=img.mime_type,
+                file_size_bytes=img.file_size_bytes,
+                extracted_text=img.extracted_text,
+                owner_id=img.owner_id,
+                created_at=img.created_at,
+                updated_at=img.updated_at,
+            )
+            for img in images
+        ],
+        total=total,
+    )
+
+
+@router.delete("/{image_id}", response_model=ImageDeleteResponse)
+async def delete_image(
+    image_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    image_service: ImageService = Depends(get_image_service),
+) -> ImageDeleteResponse:
+    """Delete an image by ID."""
+    deleted = await image_service.delete_image(session, image_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    return ImageDeleteResponse(deleted=True, id=image_id)

--- a/backend/app/services/image_service.py
+++ b/backend/app/services/image_service.py
@@ -1,0 +1,162 @@
+"""Image storage service for managing uploaded images."""
+
+import logging
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import Image
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_MIME_TYPES = frozenset(
+    {
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+        "image/svg+xml",
+    }
+)
+
+MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+class ImageService:
+    """Service for image CRUD operations."""
+
+    async def upload_image(  # noqa: PLR0913
+        self,
+        session: AsyncSession,
+        filename: str,
+        mime_type: str,
+        image_data: bytes,
+        owner_id: uuid.UUID,
+        description: str | None = None,
+    ) -> Image:
+        """Store an uploaded image in the database.
+
+        Args:
+            session: Database session.
+            filename: Original filename.
+            mime_type: MIME type of the image.
+            image_data: Raw image bytes.
+            owner_id: UUID of the owning user.
+            description: Optional description.
+
+        Returns:
+            The created Image ORM instance.
+
+        Raises:
+            ValueError: If mime_type or file size is invalid.
+        """
+        if mime_type not in ALLOWED_MIME_TYPES:
+            msg = f"Unsupported image type: {mime_type}"
+            raise ValueError(msg)
+
+        file_size = len(image_data)
+        if file_size > MAX_IMAGE_SIZE_BYTES:
+            msg = f"Image exceeds maximum size of {MAX_IMAGE_SIZE_BYTES} bytes"
+            raise ValueError(msg)
+
+        if file_size == 0:
+            msg = "Image data is empty"
+            raise ValueError(msg)
+
+        image = Image(
+            filename=filename,
+            description=description,
+            mime_type=mime_type,
+            file_size_bytes=file_size,
+            image_data=image_data,
+            owner_id=owner_id,
+        )
+        session.add(image)
+        await session.commit()
+        await session.refresh(image)
+
+        logger.info(
+            f"Image uploaded: {image.id}",
+            extra={"image_id": str(image.id), "image_filename": filename, "size": file_size},
+        )
+        return image
+
+    async def get_image(self, session: AsyncSession, image_id: uuid.UUID) -> Image | None:
+        """Retrieve a single image by ID.
+
+        Args:
+            session: Database session.
+            image_id: UUID of the image.
+
+        Returns:
+            The Image instance, or None if not found.
+        """
+        result = await session.execute(select(Image).where(Image.id == image_id))
+        return result.scalar_one_or_none()
+
+    async def list_images(
+        self,
+        session: AsyncSession,
+        owner_id: uuid.UUID,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Image], int]:
+        """List images for a given owner.
+
+        Args:
+            session: Database session.
+            owner_id: UUID of the owning user.
+            limit: Max number of images to return.
+            offset: Number of images to skip.
+
+        Returns:
+            Tuple of (list of images, total count).
+        """
+        count_result = await session.execute(
+            select(func.count()).select_from(Image).where(Image.owner_id == owner_id)
+        )
+        total = count_result.scalar_one()
+
+        result = await session.execute(
+            select(Image)
+            .where(Image.owner_id == owner_id)
+            .order_by(Image.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        images = list(result.scalars().all())
+
+        return images, total
+
+    async def delete_image(self, session: AsyncSession, image_id: uuid.UUID) -> bool:
+        """Delete an image by ID.
+
+        Args:
+            session: Database session.
+            image_id: UUID of the image to delete.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        image = await self.get_image(session, image_id)
+        if image is None:
+            return False
+
+        await session.delete(image)
+        await session.commit()
+
+        logger.info(f"Image deleted: {image_id}", extra={"image_id": str(image_id)})
+        return True
+
+
+# Singleton instance
+_image_service: ImageService | None = None
+
+
+def get_image_service() -> ImageService:
+    """Get or create ImageService instance."""
+    global _image_service
+    if _image_service is None:
+        _image_service = ImageService()
+    return _image_service

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "asyncpg>=0.29.0",  # PostgreSQL async driver
     "openai>=1.0.0",  # OpenAI API client
     "rich>=13.7.0",  # Beautiful terminal output and logging
+    "python-multipart>=0.0.6",  # File upload support
 ]
 
 [project.optional-dependencies]

--- a/backend/scripts/lint_structure.py
+++ b/backend/scripts/lint_structure.py
@@ -72,7 +72,9 @@ def check_layer_violations(file: Path, tree: ast.AST) -> None:
 
         # Routes must not import from other route files
         if rel.startswith("routes/"):
-            if (".routes." in module or module.startswith("app.routes")) and module != f"app.{rel.replace('/', '.').removesuffix('.py')}":
+            if (
+                ".routes." in module or module.startswith("app.routes")
+            ) and module != f"app.{rel.replace('/', '.').removesuffix('.py')}":
                 add_error(
                     file,
                     lineno,
@@ -172,7 +174,13 @@ def lint_file(file: Path) -> None:
         source = file.read_text()
         tree = ast.parse(source, filename=str(file))
     except SyntaxError as e:
-        add_error(file, e.lineno or 1, "PARSE001", f"Syntax error: {e.msg}", "Fix the syntax error before continuing.")
+        add_error(
+            file,
+            e.lineno or 1,
+            "PARSE001",
+            f"Syntax error: {e.msg}",
+            "Fix the syntax error before continuing.",
+        )
         return
 
     check_layer_violations(file, tree)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,17 +5,17 @@ from fastapi.testclient import TestClient
 
 from app.config import settings
 from app.main import app
-from app.services import openai_service
+from app.services import image_service, openai_service
 
 
 @pytest.fixture(autouse=True)
-def clear_openai_singleton():
-    """Automatically clear OpenAI service singleton before and after each test."""
-    # Clear singleton before test to ensure fresh state
+def clear_service_singletons():
+    """Automatically clear service singletons before and after each test."""
     openai_service._openai_service = None
+    image_service._image_service = None
     yield
-    # Clear singleton after test to prevent test pollution
     openai_service._openai_service = None
+    image_service._image_service = None
 
 
 @pytest.fixture

--- a/backend/tests/unit/test_db_models.py
+++ b/backend/tests/unit/test_db_models.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from app.db.models import Base, Document, DocumentTag, Tag, User
+from app.db.models import Base, Document, DocumentTag, Image, ImageTag, Tag, User
 
 
 def test_user_model_has_correct_tablename():
@@ -25,10 +25,20 @@ def test_document_tag_model_has_correct_tablename():
     assert DocumentTag.__tablename__ == "document_tags"
 
 
+def test_image_model_has_correct_tablename():
+    """Test Image model table name."""
+    assert Image.__tablename__ == "images"
+
+
+def test_image_tag_model_has_correct_tablename():
+    """Test ImageTag association table name."""
+    assert ImageTag.__tablename__ == "image_tags"
+
+
 def test_base_metadata_contains_all_tables():
     """Test that Base metadata knows about all tables."""
     table_names = set(Base.metadata.tables.keys())
-    expected = {"users", "documents", "tags", "document_tags"}
+    expected = {"users", "documents", "tags", "document_tags", "images", "image_tags"}
     assert expected.issubset(table_names)
 
 
@@ -118,3 +128,50 @@ def test_document_owner_id_has_foreign_key():
     fk = list(owner_col.foreign_keys)
     assert len(fk) == 1
     assert fk[0].target_fullname == "users.id"
+
+
+def test_image_columns_exist():
+    """Test that Image model has expected columns."""
+    column_names = {col.name for col in Image.__table__.columns}
+    expected = {
+        "id",
+        "filename",
+        "description",
+        "mime_type",
+        "file_size_bytes",
+        "image_data",
+        "extracted_text",
+        "owner_id",
+        "created_at",
+        "updated_at",
+    }
+    assert expected == column_names
+
+
+def test_image_tags_columns_exist():
+    """Test that ImageTag model has expected columns."""
+    column_names = {col.name for col in ImageTag.__table__.columns}
+    expected = {"image_id", "tag_id"}
+    assert expected == column_names
+
+
+def test_image_owner_id_has_foreign_key():
+    """Test that image owner_id references users table."""
+    owner_col = Image.__table__.columns["owner_id"]
+    fk = list(owner_col.foreign_keys)
+    assert len(fk) == 1
+    assert fk[0].target_fullname == "users.id"
+
+
+def test_image_repr():
+    """Test Image string representation."""
+    img = Image(
+        id=uuid.uuid4(),
+        filename="photo.jpg",
+        mime_type="image/jpeg",
+        file_size_bytes=2048,
+        image_data=b"\x00",
+        owner_id=uuid.uuid4(),
+    )
+    assert "photo.jpg" in repr(img)
+    assert "Image" in repr(img)

--- a/backend/tests/unit/test_image_models.py
+++ b/backend/tests/unit/test_image_models.py
@@ -1,0 +1,79 @@
+"""Unit tests for image Pydantic models."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.images import (
+    ImageDeleteResponse,
+    ImageListResponse,
+    ImageMetadataResponse,
+    ImageUploadResponse,
+)
+
+
+def test_image_metadata_response_valid():
+    """Test ImageMetadataResponse with valid data."""
+    now = datetime.now(tz=UTC)
+    resp = ImageMetadataResponse(
+        id=uuid.uuid4(),
+        filename="photo.jpg",
+        description="A test photo",
+        mime_type="image/jpeg",
+        file_size_bytes=1024,
+        extracted_text=None,
+        owner_id=uuid.uuid4(),
+        created_at=now,
+        updated_at=now,
+    )
+    assert resp.filename == "photo.jpg"
+    assert resp.file_size_bytes == 1024
+
+
+def test_image_metadata_response_negative_size():
+    """Test ImageMetadataResponse rejects negative file size."""
+    now = datetime.now(tz=UTC)
+    with pytest.raises(ValidationError):
+        ImageMetadataResponse(
+            id=uuid.uuid4(),
+            filename="photo.jpg",
+            mime_type="image/jpeg",
+            file_size_bytes=-1,
+            owner_id=uuid.uuid4(),
+            created_at=now,
+            updated_at=now,
+        )
+
+
+def test_image_upload_response_valid():
+    """Test ImageUploadResponse with valid data."""
+    resp = ImageUploadResponse(
+        id=uuid.uuid4(),
+        filename="photo.png",
+        mime_type="image/png",
+        file_size_bytes=2048,
+    )
+    assert resp.mime_type == "image/png"
+
+
+def test_image_delete_response_valid():
+    """Test ImageDeleteResponse with valid data."""
+    img_id = uuid.uuid4()
+    resp = ImageDeleteResponse(deleted=True, id=img_id)
+    assert resp.deleted is True
+    assert resp.id == img_id
+
+
+def test_image_list_response_valid():
+    """Test ImageListResponse with valid data."""
+    resp = ImageListResponse(images=[], total=0)
+    assert resp.total == 0
+    assert resp.images == []
+
+
+def test_image_list_response_negative_total():
+    """Test ImageListResponse rejects negative total."""
+    with pytest.raises(ValidationError):
+        ImageListResponse(images=[], total=-1)

--- a/backend/tests/unit/test_image_routes.py
+++ b/backend/tests/unit/test_image_routes.py
@@ -1,0 +1,190 @@
+"""Unit tests for image endpoints."""
+
+import io
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from app.db.base import get_session
+from app.main import app
+from app.services.image_service import get_image_service
+
+
+def _mock_image(image_id: uuid.UUID | None = None, owner_id: uuid.UUID | None = None) -> MagicMock:
+    """Create a mock Image ORM object."""
+    now = datetime.now(tz=UTC)
+    img = MagicMock()
+    img.id = image_id or uuid.uuid4()
+    img.filename = "test.png"
+    img.description = "A test image"
+    img.mime_type = "image/png"
+    img.file_size_bytes = 1024
+    img.extracted_text = None
+    img.owner_id = owner_id or uuid.uuid4()
+    img.created_at = now
+    img.updated_at = now
+    return img
+
+
+def test_upload_image_success(client):
+    """Test successful image upload."""
+    owner_id = uuid.uuid4()
+    mock_service = MagicMock()
+    mock_img = _mock_image(owner_id=owner_id)
+    mock_service.upload_image = AsyncMock(return_value=mock_img)
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.post(
+            f"/api/v1/images?owner_id={owner_id}",
+            files={"file": ("test.png", io.BytesIO(b"\x89PNG\r\n\x1a\n"), "image/png")},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["filename"] == "test.png"
+        assert data["mime_type"] == "image/png"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_upload_image_non_image_content_type(client):
+    """Test upload rejects non-image files."""
+    owner_id = uuid.uuid4()
+    mock_session = AsyncMock()
+    mock_service = MagicMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.post(
+            f"/api/v1/images?owner_id={owner_id}",
+            files={"file": ("file.txt", io.BytesIO(b"hello"), "text/plain")},
+        )
+        assert response.status_code == 400
+        assert "image" in response.json()["detail"].lower()
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_upload_image_service_value_error(client):
+    """Test upload returns 400 when service raises ValueError."""
+    owner_id = uuid.uuid4()
+    mock_service = MagicMock()
+    mock_service.upload_image = AsyncMock(
+        side_effect=ValueError("Unsupported image type: image/bmp")
+    )
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.post(
+            f"/api/v1/images?owner_id={owner_id}",
+            files={"file": ("test.bmp", io.BytesIO(b"\x00" * 10), "image/bmp")},
+        )
+        assert response.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_get_image_success(client):
+    """Test retrieving image metadata."""
+    mock_img = _mock_image()
+    mock_service = MagicMock()
+    mock_service.get_image = AsyncMock(return_value=mock_img)
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.get(f"/api/v1/images/{mock_img.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["filename"] == "test.png"
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_get_image_not_found(client):
+    """Test 404 for non-existent image."""
+    mock_service = MagicMock()
+    mock_service.get_image = AsyncMock(return_value=None)
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.get(f"/api/v1/images/{uuid.uuid4()}")
+        assert response.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_list_images_success(client):
+    """Test listing images for an owner."""
+    owner_id = uuid.uuid4()
+    mock_imgs = [_mock_image(owner_id=owner_id), _mock_image(owner_id=owner_id)]
+    mock_service = MagicMock()
+    mock_service.list_images = AsyncMock(return_value=(mock_imgs, 2))
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.get(f"/api/v1/images?owner_id={owner_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["images"]) == 2
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_delete_image_success(client):
+    """Test successful image deletion."""
+    image_id = uuid.uuid4()
+    mock_service = MagicMock()
+    mock_service.delete_image = AsyncMock(return_value=True)
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.delete(f"/api/v1/images/{image_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["deleted"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_delete_image_not_found(client):
+    """Test 404 when deleting non-existent image."""
+    mock_service = MagicMock()
+    mock_service.delete_image = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+
+    app.dependency_overrides[get_image_service] = lambda: mock_service
+    app.dependency_overrides[get_session] = lambda: mock_session
+
+    try:
+        response = client.delete(f"/api/v1/images/{uuid.uuid4()}")
+        assert response.status_code == 404
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/unit/test_image_service.py
+++ b/backend/tests/unit/test_image_service.py
@@ -1,0 +1,157 @@
+"""Unit tests for image service."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.image_service import (
+    ALLOWED_MIME_TYPES,
+    MAX_IMAGE_SIZE_BYTES,
+    ImageService,
+)
+
+
+@pytest.fixture
+def image_service():
+    """Create a fresh ImageService instance."""
+    return ImageService()
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock async database session."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def sample_image_data():
+    """Return minimal valid image bytes."""
+    return b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+
+@pytest.fixture
+def owner_id():
+    """Return a fixed owner UUID."""
+    return uuid.uuid4()
+
+
+@pytest.mark.asyncio
+async def test_upload_image_success(image_service, mock_session, sample_image_data, owner_id):
+    """Test successful image upload."""
+    mock_image = MagicMock()
+    mock_image.id = uuid.uuid4()
+    mock_image.filename = "photo.png"
+    mock_image.mime_type = "image/png"
+    mock_image.file_size_bytes = len(sample_image_data)
+
+    with patch("app.services.image_service.Image", return_value=mock_image):
+        result = await image_service.upload_image(
+            session=mock_session,
+            filename="photo.png",
+            mime_type="image/png",
+            image_data=sample_image_data,
+            owner_id=owner_id,
+        )
+
+    mock_session.add.assert_called_once()
+    mock_session.commit.assert_awaited_once()
+    mock_session.refresh.assert_awaited_once()
+    assert result is mock_image
+
+
+@pytest.mark.asyncio
+async def test_upload_image_invalid_mime_type(
+    image_service, mock_session, sample_image_data, owner_id
+):
+    """Test upload rejects unsupported MIME types."""
+    with pytest.raises(ValueError, match="Unsupported image type"):
+        await image_service.upload_image(
+            session=mock_session,
+            filename="file.txt",
+            mime_type="text/plain",
+            image_data=sample_image_data,
+            owner_id=owner_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_image_too_large(image_service, mock_session, owner_id):
+    """Test upload rejects images exceeding size limit."""
+    big_data = b"\x00" * (MAX_IMAGE_SIZE_BYTES + 1)
+    with pytest.raises(ValueError, match="exceeds maximum size"):
+        await image_service.upload_image(
+            session=mock_session,
+            filename="huge.png",
+            mime_type="image/png",
+            image_data=big_data,
+            owner_id=owner_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_image_empty_data(image_service, mock_session, owner_id):
+    """Test upload rejects empty image data."""
+    with pytest.raises(ValueError, match="empty"):
+        await image_service.upload_image(
+            session=mock_session,
+            filename="empty.png",
+            mime_type="image/png",
+            image_data=b"",
+            owner_id=owner_id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_image_found(image_service, mock_session):
+    """Test retrieving an existing image."""
+    mock_image = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_image
+    mock_session.execute.return_value = mock_result
+
+    result = await image_service.get_image(mock_session, uuid.uuid4())
+    assert result is mock_image
+
+
+@pytest.mark.asyncio
+async def test_get_image_not_found(image_service, mock_session):
+    """Test retrieving a non-existent image returns None."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    result = await image_service.get_image(mock_session, uuid.uuid4())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_image_success(image_service, mock_session):
+    """Test successful image deletion."""
+    mock_image = MagicMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_image
+    mock_session.execute.return_value = mock_result
+
+    result = await image_service.delete_image(mock_session, uuid.uuid4())
+    assert result is True
+    mock_session.delete.assert_awaited_once_with(mock_image)
+    mock_session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_image_not_found(image_service, mock_session):
+    """Test deleting a non-existent image returns False."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = mock_result
+
+    result = await image_service.delete_image(mock_session, uuid.uuid4())
+    assert result is False
+
+
+def test_allowed_mime_types_contains_common_formats():
+    """Test that common image formats are in the allowed list."""
+    assert "image/jpeg" in ALLOWED_MIME_TYPES
+    assert "image/png" in ALLOWED_MIME_TYPES
+    assert "image/webp" in ALLOWED_MIME_TYPES

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -550,6 +550,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "rich" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
@@ -581,6 +582,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sqlalchemy", specifier = ">=2.0.23" },
@@ -831,6 +833,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR adds comprehensive image upload, retrieval, listing, and deletion functionality to the backend. It includes a new `ImageService` for business logic, REST API endpoints, database models with migrations, Pydantic schemas for request/response validation, and comprehensive unit tests.

## Key Changes

### Database & Models
- Added `Image` ORM model to store uploaded images with metadata (filename, MIME type, file size, extracted text, timestamps)
- Added `ImageTag` association table for many-to-many relationship between images and tags
- Created Alembic migration (`a1b2c3d4e5f6`) to create `images` and `image_tags` tables
- Updated `User` and `Tag` models with relationships to images

### Service Layer
- Implemented `ImageService` class with CRUD operations:
  - `upload_image()`: Validates MIME type (JPEG, PNG, GIF, WebP, SVG), enforces 10MB size limit, stores image data
  - `get_image()`: Retrieves single image by ID
  - `list_images()`: Lists images for an owner with pagination
  - `delete_image()`: Deletes image by ID
- Added singleton pattern for service instantiation via `get_image_service()`

### API Routes
- Created `/api/v1/images` endpoints:
  - `POST /api/v1/images`: Upload image with owner_id and optional description
  - `GET /api/v1/images/{image_id}`: Retrieve image metadata
  - `GET /api/v1/images`: List images for owner with pagination
  - `DELETE /api/v1/images/{image_id}`: Delete image
- Proper HTTP status codes (201 for creation, 404 for not found, 400 for validation errors)

### Pydantic Models
- `ImageMetadataResponse`: Full image metadata without binary data
- `ImageUploadResponse`: Response after successful upload
- `ImageListResponse`: Paginated list of images
- `ImageDeleteResponse`: Confirmation of deletion
- All models include field validation (non-negative sizes, etc.)

### Testing
- Unit tests for `ImageService` covering success cases, validation errors, size limits, and edge cases
- Unit tests for image routes covering upload, retrieval, listing, and deletion with mocked dependencies
- Unit tests for Pydantic models validating schema constraints
- Updated database model tests to verify Image and ImageTag tables

### Dependencies
- Added `python-multipart>=0.0.6` for file upload support in FastAPI

### Infrastructure
- Updated test fixtures to clear both OpenAI and image service singletons
- Updated main app to include new image routes

https://claude.ai/code/session_01EE8sc34gXWcC5HUe1peTJe